### PR TITLE
Update validate VIN logic to support Japanese chassis number

### DIFF
--- a/internal/attestation/repos/fingerprint/fingerprint.go
+++ b/internal/attestation/repos/fingerprint/fingerprint.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/DIMO-Network/attestation-api/internal/client/fetchapi"
@@ -21,10 +20,6 @@ import (
 )
 
 type decodeError string
-
-const vinRegex = `^[A-Z0-9]{17}$`
-
-var basicVINExp = regexp.MustCompile(vinRegex)
 
 func (d decodeError) Error() string {
 	return fmt.Sprintf("failed to decode fingerprint message: %s", string(d))
@@ -95,8 +90,8 @@ func (s *Service) decodeFingerprintMessage(ctx context.Context, msg cloudevent.R
 	if !validateVIN(vin) {
 		return nil, ctrlerrors.Error{
 			Code:          http.StatusBadRequest,
-			InternalError: decodeError("invalid vin"),
-			ExternalMsg:   fmt.Sprintf("VIN in vehicle payload was did not match expected format %s", vinRegex),
+			InternalError: decodeError("invalid vin " + vin),
+			ExternalMsg:   fmt.Sprintf("VIN in vehicle payload failed validation rules %s", vin),
 		}
 	}
 	return &models.DecodedFingerprintData{

--- a/internal/attestation/repos/fingerprint/fingerprint.go
+++ b/internal/attestation/repos/fingerprint/fingerprint.go
@@ -16,6 +16,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	vinutil "github.com/DIMO-Network/shared/pkg/vin"
 )
 
 type decodeError string
@@ -90,10 +92,10 @@ func (s *Service) decodeFingerprintMessage(ctx context.Context, msg cloudevent.R
 	vin = strings.ToUpper(strings.ReplaceAll(vin, " ", ""))
 
 	// We have seen crazy VINs like "\u000" before.
-	if !basicVINExp.MatchString(vin) {
+	if !validateVIN(vin) {
 		return nil, ctrlerrors.Error{
 			Code:          http.StatusBadRequest,
-			InternalError: decodeError("invalid vin regex"),
+			InternalError: decodeError("invalid vin"),
 			ExternalMsg:   fmt.Sprintf("VIN in vehicle payload was did not match expected format %s", vinRegex),
 		}
 	}
@@ -101,4 +103,16 @@ func (s *Service) decodeFingerprintMessage(ctx context.Context, msg cloudevent.R
 		CloudEventHeader: msg.CloudEventHeader,
 		VIN:              vin,
 	}, nil
+}
+
+// validateVIN checks if VIN is valid as a 17 character traditional VIN or as a japanese chassis number
+func validateVIN(vin string) bool {
+	vinObj := vinutil.VIN(vin)
+
+	if vinObj.IsValidVIN() {
+		return true
+	} else if vinObj.IsValidJapanChassis() {
+		return true
+	}
+	return false
 }

--- a/internal/attestation/repos/fingerprint/fingerprint_test.go
+++ b/internal/attestation/repos/fingerprint/fingerprint_test.go
@@ -110,7 +110,7 @@ func TestDecodeFingerprintMessage(t *testing.T) {
 					Source:      common.HexToAddress("0x4c674ddE8189aEF6e3b58F5a36d7438b2b1f6Bc2").String(), // hashdog source
 					Type:        cloudevent.TypeFingerprint,
 				},
-				VIN: "1ABCD2EFGH3JKLMNO",
+				VIN: "1ABCD2EFGH3JKLMN0",
 			},
 		},
 		{
@@ -322,7 +322,7 @@ var hashdogFPPayload = `{
       "protocol": 6,
       "signature": "0x9a8b7c6d5e4f3g2h1i0j9k8l7m6n5o4p3q2r1s0t9u8v7w6x5y4z3a2b1c0d9e8f7g6h5i4j3k2l1m",
       "timestamp": "2025-03-05T12:46:32.000Z",
-      "vin": "1ABCD2EFGH3JKLMNO"
+      "vin": "1ABCD2EFGH3JKLMN0"
     },
     "device": {
       "id": "A1B2C3D4E5F6G7H8",

--- a/internal/attestation/repos/fingerprint/fingerprint_test.go
+++ b/internal/attestation/repos/fingerprint/fingerprint_test.go
@@ -160,6 +160,72 @@ func TestDecodeFingerprintMessage(t *testing.T) {
 	}
 }
 
+func TestValidateVIN(t *testing.T) {
+	tests := []struct {
+		name     string
+		vin      string
+		expected bool
+	}{
+		{
+			name:     "Valid Japanese chassis number",
+			vin:      "SNT33-042261",
+			expected: true,
+		},
+		{
+			name:     "Valid 17 character VIN",
+			vin:      "1FTFX1E57JKE37092",
+			expected: true,
+		},
+		{
+			name:     "Invalid VIN - too short but valid Japanese chassis",
+			vin:      "123456789",
+			expected: true, // This is actually a valid Japanese chassis format
+		},
+		{
+			name:     "Invalid VIN - too long",
+			vin:      "1FTFX1E57JKE37092EXTRA",
+			expected: false,
+		},
+		{
+			name:     "Invalid VIN - contains invalid characters",
+			vin:      "1FTFX1E57JKE3709I", // 'I' is not allowed in VINs
+			expected: false,
+		},
+		{
+			name:     "Empty VIN",
+			vin:      "",
+			expected: false,
+		},
+		{
+			name:     "VIN with only spaces",
+			vin:      "   ",
+			expected: false,
+		},
+		{
+			name:     "Short Japanese chassis - still valid",
+			vin:      "SNT33-04226",
+			expected: true, // This is actually a valid Japanese chassis format
+		},
+		{
+			name:     "Long Japanese chassis - still valid",
+			vin:      "SNT33-0422611",
+			expected: true, // This is actually a valid Japanese chassis format
+		},
+		{
+			name:     "Invalid format - wrong Japanese chassis pattern",
+			vin:      "SNT-33042261",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateVIN(tt.vin)
+			require.Equal(t, tt.expected, result, "VIN: %s", tt.vin)
+		})
+	}
+}
+
 var ruptelaStatusPayload = `
 {
 	"source": "0xF26421509Efe92861a587482100c6d728aBf1CD0",


### PR DESCRIPTION
- updated logic based on what already had in shared package. First checks for 17 style vin and then for japanese vin, if both fail then return false
- added tests, some may be repetitive with underlying shared pkg but I think provides some guard against future changes.